### PR TITLE
Fix macOS support

### DIFF
--- a/src/DeviceManager.ts
+++ b/src/DeviceManager.ts
@@ -3,6 +3,7 @@ import './Utils';
 import * as fs from 'fs';
 import { spawnSync, spawn } from 'child_process';
 import { Utils } from './Utils';
+import { PathHelper } from './PathHelper';
 
 interface DevicesList {
     name: string;
@@ -25,10 +26,6 @@ export class DeviceManager {
 
     private vBoxManageName(): string {
         return Utils.isWin() ? "VBoxManage.exe" : "VBoxManage";
-    }
-
-    private playerName(): string {
-        return Utils.isWin() ? "player.exe" : "player";
     }
 
     private isGenymotionDevice(uuid: string): boolean {
@@ -84,7 +81,7 @@ export class DeviceManager {
     }
 
     startDevice(uuid: string) {
-        spawn(Utils.isWin() ? this.playerName() : "./" + this.playerName(), ["--vm-name", uuid], {
+        spawn(PathHelper.playerPath(this.genyPath), ["--vm-name", uuid], {
             cwd: this.genyPath,
             stdio: 'ignore',
             detached: true

--- a/src/PathHelper.ts
+++ b/src/PathHelper.ts
@@ -63,18 +63,28 @@ export class PathHelper {
         if (!path || path === "") {
             return false;
         } else {
-            if (Utils.isMac()) {
-                path += separator + "Contents" + separator + "MacOS" + separator
-                    + "player.app" + separator + "Contents" + separator + "MacOS";
-            }
-
-            path = path.slice(-1) === "/" || path.slice(-1) === "\\" ? path : path + separator;
-            path += Utils.isWin() ? "player.exe" : "player";
-            if (fs.existsSync(path)) {
+            if (fs.existsSync(PathHelper.playerPath(path))) {
                 return true;
             }
         }
         return false;
+    }
+
+    static genymotionPath(genyPath: string): string {
+        if (Utils.isMac()) {
+            genyPath += separator + "Contents" + separator + "MacOS";
+        }
+        genyPath += separator + (Utils.isWin() ? "genymotion.exe" : "genymotion");
+        return genyPath;
+    }
+
+    static playerPath(genyPath: string): string {
+        if (Utils.isMac()) {
+            genyPath += separator + "Contents" + separator + "MacOS" + separator
+                + "player.app" + separator + "Contents" + separator + "MacOS";
+        }
+        genyPath += separator + (Utils.isWin() ? "player.exe" : "player");
+        return genyPath;
     }
 
     static verifyVBoxPath(path: string): boolean {
@@ -82,8 +92,7 @@ export class PathHelper {
             return false;
         } else {
             if (Utils.isMac()) {
-                path += separator + "Contents" + separator + "MacOS" + separator
-                    + "VBoxManage.app" + separator + "Contents" + separator + "MacOS";
+                path += separator + "Contents" + separator + "MacOS";
             }
 
             path = path.slice(-1) === "/" || path.slice(-1) === "\\" ? path : path + separator;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,12 +195,13 @@ function commandSetting() {
 	}).then( item => {
 		if (item) {
 			let isGenymotion = item.isGenymotion;
+			let pathIsFolder = !Utils.isMac();
 
 			if (isGenymotion) {
 				vscode.window.showOpenDialog(
 					{
-						canSelectFiles: false,
-						canSelectFolders: true,
+						canSelectFiles: !pathIsFolder,
+						canSelectFolders: pathIsFolder,
 						canSelectMany: false,
 						openLabel: "Genymotion Path...",
 					},
@@ -219,8 +220,8 @@ function commandSetting() {
 			} else {
 				vscode.window.showOpenDialog(
 					{
-						canSelectFiles: false,
-						canSelectFolders: true,
+						canSelectFiles: !pathIsFolder,
+						canSelectFolders: pathIsFolder,
 						canSelectMany: false,
 						openLabel: "VirtualBox Path...",
 					},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -246,7 +246,7 @@ function commandSetting() {
 function commandOpen() {
 	readConfigurations();
 	if (genyPath) {
-		spawn(Utils.isWin() ? "genymotion.exe" : "genymotion", {
+		spawn(PathHelper.genymotionPath(genyPath), {
 			cwd: genyPath
 		});
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,52 @@ function readConfigurations() {
 	vboxPath = vscode.workspace.getConfiguration("genymotion").get(VIRTUALBOX_FOLDER_CONF, "");
 }
 
+function selectGenymotionPath() {
+	let pathIsFolder = !Utils.isMac();
+
+	vscode.window.showOpenDialog(
+		{
+			canSelectFiles: !pathIsFolder,
+			canSelectFolders: pathIsFolder,
+			canSelectMany: false,
+			openLabel: "Genymotion Path...",
+		},
+	).then( async fileUri => {
+		if (fileUri && fileUri[0]) {
+			vscode.workspace.getConfiguration("genymotion").update(GENYMOTION_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
+				if (PathHelper.verifyGenyPath(fileUri[0].fsPath)) {
+					vscode.window.showInformationMessage("`Genymotion` path was detected succesfully.");
+				} else {
+					vscode.window.showErrorMessage("The detected path for `Genymotion` is not correct.");
+				}
+			});
+		}
+	});
+}
+
+function selectVirtualBoxPath() {
+	let pathIsFolder = !Utils.isMac();
+	vscode.window.showOpenDialog(
+		{
+			canSelectFiles: !pathIsFolder,
+			canSelectFolders: pathIsFolder,
+			canSelectMany: false,
+			openLabel: "VirtualBox Path...",
+		},
+	).then( async fileUri => {
+		if (fileUri && fileUri[0]) {
+			vscode.workspace.getConfiguration("genymotion").update(VIRTUALBOX_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
+				if (PathHelper.verifyVBoxPath(fileUri[0].fsPath)) {
+					vscode.window.showInformationMessage("`VirtualBox` path was detected succesfully.");
+				} else {
+					vscode.window.showErrorMessage("The detected path for `Virtual Box` is not correct.");
+				}
+			});
+
+		}
+	});
+}
+
 function detectePathes(): boolean {
 	
 	let statusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
@@ -60,27 +106,7 @@ function detectePathes(): boolean {
 		).then(choice => {
 			// OnDetecte Selected
 			if (choice === "Detecte Path") {
-				vscode.window.showOpenDialog(
-					{
-						canSelectFiles: false,
-						canSelectFolders: true,
-						canSelectMany: false,
-						openLabel: "Genymotion Path...",
-					},
-				).then( async fileUri => {
-					if (fileUri && fileUri[0]) {
-						vscode.workspace.getConfiguration("genymotion").update(GENYMOTION_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
-							if (PathHelper.verifyGenyPath(fileUri[0].fsPath)) {
-								vscode.window.showInformationMessage("`Genymotion` path was detected succesfully.");
-							} else {
-								vscode.window.showErrorMessage("The detected path for `Genymotion` is not correct.");
-							}
-						});
-						
-					} else  {
-						vscode.window.showWarningMessage("Please detecte `Genymotion` path in setting.");
-					}
-				});
+				selectGenymotionPath();
 			}
 		});
 	}
@@ -93,27 +119,7 @@ function detectePathes(): boolean {
 			"Can't detecte `VirtualBox` Path. Detecte it here or Go to settings and Genymotion session.", ...["Detecte Path", "Dismise"]
 		).then(choice => {
 			if (choice === "Detecte Path") {
-				vscode.window.showOpenDialog(
-					{
-						canSelectFiles: false,
-						canSelectFolders: true,
-						canSelectMany: false,
-						openLabel: "VirtualBox Path...",
-					},
-				).then( async fileUri => {
-					if (fileUri && fileUri[0]) {
-						vscode.workspace.getConfiguration("genymotion").update(VIRTUALBOX_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
-							if (PathHelper.verifyVBoxPath(fileUri[0].fsPath)) {
-								vscode.window.showInformationMessage("`VirtualBox` path was detected succesfully.");
-							} else {
-								vscode.window.showErrorMessage("The detected path for `Virtual Box` is not correct.");
-							}
-						});
-							
-					} else  {
-						vscode.window.showWarningMessage("Please detecte `VirtualBox` path in setting.");
-					}
-				});
+				selectVirtualBoxPath();
 			}
 		});
 	}
@@ -171,7 +177,6 @@ function commandStart() {
 	return;
 }
 
-
 function commandSetting() {
 	readConfigurations();
 	let items = [
@@ -194,49 +199,10 @@ function commandSetting() {
 		ignoreFocusOut: false,
 	}).then( item => {
 		if (item) {
-			let isGenymotion = item.isGenymotion;
-			let pathIsFolder = !Utils.isMac();
-
-			if (isGenymotion) {
-				vscode.window.showOpenDialog(
-					{
-						canSelectFiles: !pathIsFolder,
-						canSelectFolders: pathIsFolder,
-						canSelectMany: false,
-						openLabel: "Genymotion Path...",
-					},
-				).then( async fileUri => {
-					if (fileUri && fileUri[0]) {
-						vscode.workspace.getConfiguration("genymotion").update(GENYMOTION_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
-							if (PathHelper.verifyGenyPath(fileUri[0].fsPath)) {
-								vscode.window.showInformationMessage("`Genymotion` path was detected succesfully.");
-							} else {
-								vscode.window.showErrorMessage("The detected path for `Genymotion` is not correct.");
-							}
-						});
-					}
-				});
-
+			if (item.isGenymotion) {
+				selectGenymotionPath();
 			} else {
-				vscode.window.showOpenDialog(
-					{
-						canSelectFiles: !pathIsFolder,
-						canSelectFolders: pathIsFolder,
-						canSelectMany: false,
-						openLabel: "VirtualBox Path...",
-					},
-				).then( async fileUri => {
-					if (fileUri && fileUri[0]) {
-						vscode.workspace.getConfiguration("genymotion").update(VIRTUALBOX_FOLDER_CONF, fileUri[0].fsPath, true).then(par => {
-							if (PathHelper.verifyVBoxPath(fileUri[0].fsPath)) {
-								vscode.window.showInformationMessage("`VirtualBox` path was detected succesfully.");
-							} else {
-								vscode.window.showErrorMessage("The detected path for `Virtual Box` is not correct.");
-							}
-						});
-							
-					}
-				});
+				selectVirtualBoxPath();
 			}
 			
 		}


### PR DESCRIPTION
This PR makes the extension work on macOS. It does the following:

- Fix the path to VBoxManage
- Use full paths for the `genymotion` and `player` binaries: for some reason this helps starting them, even if the working directory is correctly set
- Fix selecting the VirtualBox and Genymotion installation directory: on macOS the file selectors must select files not directories, because macOS UI shows .app bundles as files
- Factorize code opening the file dialogs